### PR TITLE
Add all-contributors and codeowners

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,14 @@
+{
+  "projectName": "product-bookmark-interfaces",
+  "projectOwner": "vtex-apps",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "docs/README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributors": [],
+  "contributorsPerLine": 7
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @vtex-apps/store-framework-devs
+docs/ @vtex-apps/technical-writers

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,23 @@
 # Product Bookmark Interfaces
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 > Interfaces for a wishlist or list app.
 
 This app provides extensible interfaces that can be used by the `vtex.store` and a theme app. A wishlist or list app would depend on this app and extend the interfaces provided to become available in the store.
 
 You can see an example of a wishlist app [here](/example).
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
This automated pull request aims to:

- Add `all-contributors` to the project.
- Add `CODEOWNERS` with mentions to the store-framework dev team and the tech-writers team for `docs` changes.